### PR TITLE
Modify JWT generators to accept custom claims

### DIFF
--- a/src/Jwt/FirebaseGenerator.php
+++ b/src/Jwt/FirebaseGenerator.php
@@ -34,23 +34,22 @@ class FirebaseGenerator implements GeneratorInterface
     }
 
     /**
-     * @param string $subject
+     * @param array $claims
      * @return string
      */
-    public function getToken($subject)
+    public function getToken(array $claims = [])
     {
         $issuer = (string) $this->request->getUri();
         $issued_at = $this->config->getTimestamp();
         $expiration = $issued_at + $this->config->getTtl();
         $key = $this->config->getPublicKey();
         $algorithm = $this->config->getAlgorithm();
-        $data = [
+        $claims += [
             'iss' => $issuer,
             'iat' => $issued_at,
             'exp' => $expiration,
-            'sub' => $subject,
         ];
-        return JWT::encode($data, $key, $algorithm);
+        return JWT::encode($claims, $key, $algorithm);
     }
 }
 

--- a/src/Jwt/GeneratorInterface.php
+++ b/src/Jwt/GeneratorInterface.php
@@ -7,8 +7,8 @@ namespace Spark\Auth\Jwt;
 interface GeneratorInterface
 {
     /**
-     * @param string $subject
+     * @param array $claims
      * @return string
      */
-    public function getToken($subject);
+    public function getToken(array $claims = []);
 }

--- a/src/Jwt/LcobucciGenerator.php
+++ b/src/Jwt/LcobucciGenerator.php
@@ -50,18 +50,20 @@ class LcobucciGenerator implements GeneratorInterface
     }
 
     /**
-     * @param string $subject
+     * @param array $claims
      * @return string
      */
-    public function getToken($subject)
+    public function getToken(array $claims = [])
     {
         $issuer = (string) $this->request->getUri();
         $issued_at = $this->config->getTimestamp();
         $expiration = $issued_at + $this->config->getTtl();
         $key = $this->config->getPrivateKey();
+        foreach ($claims as $name => $value) {
+            $this->builder->set($name, $value);
+        }
         $token = $this->builder
             ->setIssuer($issuer)
-            ->setSubject($subject)
             ->setIssuedAt($issued_at)
             ->setExpiration($expiration)
             ->sign($this->signer, $key)

--- a/tests/Jwt/FirebaseGeneratorTest.php
+++ b/tests/Jwt/FirebaseGeneratorTest.php
@@ -42,13 +42,13 @@ class FirebaseGeneratorTest extends TestCase
         );
 
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNiwic3ViIjoidXNlci0xIn0.GOXGA2n7CvKt9_1UoyGx7abV4HYKD6F8A2zk-wGwTw8',
-            $generator->getToken('user-1')
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.GDHf_4g2EYwkBAr5RQvkmiMHXvNkbjgmQoe1wLc4pfM',
+            $generator->getToken(['sub' => 'user-1'])
         );
 
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNiwic3ViIjoidXNlci0yIn0.cmqTqaQyiTJ0lI_PfkFKgCrGMwWkbXqp15UZuMO-rHU',
-            $generator->getToken('user-2')
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTIiLCJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.YBibGrGQPAOFyAe-NbMQhogvJsRPHR45zdlUolk-68I',
+            $generator->getToken(['sub' => 'user-2'])
         );
     }
 
@@ -62,13 +62,13 @@ class FirebaseGeneratorTest extends TestCase
         );
 
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNiwic3ViIjoidXNlci0xIn0.GnFhK7JaIxNqkFTRXFp8WpMre40tehHPY-B6KQhEjK7LGn6f8PO61y158llOpKLd6PqT_RDK9hHNx9Ka6rIGxA',
-            $generator->getToken('user-1')
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyLTEiLCJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.dUp_wNsYyAPE8HVyvpMgGwBR-jpZsdn2D0fEutV8Rmlq3Jpsgcbh1TX3ImK8KJm2qxMRxu1JY4hxepO-HkaxxA',
+            $generator->getToken(['sub' => 'user-1'])
         );
 
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNiwic3ViIjoidXNlci0yIn0.oEJ78pKdj5VR2bCb8lEWf8IqGcFruU2ypZwm3Cb_YIZXdNu5LXuWEd4S14VLzxaKPu785v8_mmwmMGjNOFwoxQ',
-            $generator->getToken('user-2')
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyLTIiLCJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.1Q8JBWJIum6EQoxl6cDQeoruqrjY8_kfA5q1ezZhyt5Z-oXsgtMv0KBa2qTQLjJMNk00OAl1WGLSWaEFD103hQ',
+            $generator->getToken(['sub' => 'user-2'])
         );
     }
 }

--- a/tests/Jwt/FirebaseParserTest.php
+++ b/tests/Jwt/FirebaseParserTest.php
@@ -44,10 +44,10 @@ class FirebaseParserTest extends TestCase
         Phake::when($this->config)->getAlgorithm()->thenReturn($algorithm);
 
         $this->parsed = [
+            'sub' => 'user-1',
             'iss' => $uri,
             'iat' => $timestamp,
             'exp' => $timestamp + $ttl,
-            'sub' => 'user-1',
         ];
     }
 
@@ -90,7 +90,7 @@ class FirebaseParserTest extends TestCase
 
     protected function parseToken(FirebaseGenerator $generator, FirebaseParser $parser)
     {
-        $token_string = $generator->getToken($this->parsed['sub']);
+        $token_string = $generator->getToken(['sub' => $this->parsed['sub']]);
         $token = $parser->parseToken($token_string);
 
         $this->assertInstanceOf(Token::class, $token);

--- a/tests/Jwt/LcobucciGeneratorTest.php
+++ b/tests/Jwt/LcobucciGeneratorTest.php
@@ -60,8 +60,8 @@ class LcobucciGeneratorTest extends TestCase
         );
         
         $this->assertSame(
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cmkiLCJzdWIiOiJ1c2VyLTEiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.LvaP-PZkD1SZ10K7TPUWeXiAIoTsMaacAyMKkROJWhg',
-            $generator->getToken('user-1')
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJpc3MiOiJ1cmkiLCJpYXQiOjE0NDM3MTkyMzYsImV4cCI6MTQ0MzcyMjgzNn0.GDHf_4g2EYwkBAr5RQvkmiMHXvNkbjgmQoe1wLc4pfM',
+            $generator->getToken(['sub' => 'user-1'])
         );
     }
 }

--- a/tests/Jwt/LcobucciParserTest.php
+++ b/tests/Jwt/LcobucciParserTest.php
@@ -61,7 +61,7 @@ class LcobucciParserTest extends TestCase
         $generator = $this->getGenerator($config);
         $parser = $this->getParser($config, $timestamp);
 
-        $token = $generator->getToken($this->subject);
+        $token = $generator->getToken(['sub' => $this->subject]);
         $parsed = $parser->parseToken($token);
         $this->assertInstanceOf(Token::class, $parsed);
         $this->assertSame($token, $parsed->getToken());
@@ -78,7 +78,7 @@ class LcobucciParserTest extends TestCase
         $currentConfig = $this->getMockConfiguration($currentTimestamp);
         $parser = $this->getParser($currentConfig, $currentTimestamp);
 
-        $token = $generator->getToken($this->subject);
+        $token = $generator->getToken(['sub' => $this->subject]);
 
         try {
             $parsed = $parser->parseToken($token);
@@ -139,8 +139,8 @@ class LcobucciParserTest extends TestCase
     protected function getParsed($timestamp)
     {
         return [
-            'iss' => 'uri',
             'sub' => $this->subject,
+            'iss' => 'uri',
             'iat' => $timestamp,
             'exp' => $timestamp + $this->ttl,
         ];


### PR DESCRIPTION
Before this change, `GeneratorInterface->getToken()` only accepts a
subject. This is inflexible with respect to being able to store
custom claims in generated tokens. It also goes against the JWT
spec, which states that the [subject is an optional claim](https://tools.ietf.org/html/rfc7519#section-4.1.2).

This change modifies `getToken()` to take an optional associative
array of claims and internally adds a common set of claims to it
where they are not already set.