### PR TITLE
Remove dependency on ADR interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
-        "psr/http-message": "^1",
-        "sparkphp/adr": "^0.2"
+        "psr/http-message": "^1"
     },
     "require-dev": {
         "firebase/php-jwt": "^3",

--- a/src/AuthHandler.php
+++ b/src/AuthHandler.php
@@ -4,13 +4,12 @@ namespace Spark\Auth;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Spark\Adr\MiddlewareInterface;
 use Spark\Auth\AdapterInterface;
 use Spark\Auth\Credentials\ExtractorInterface as CredentialsExtractor;
 use Spark\Auth\Token\ExtractorInterface as TokenExtractor;
 use Spark\Auth\Exception\UnauthorizedException;
 
-class AuthHandler implements MiddlewareInterface
+class AuthHandler
 {
     const TOKEN_ATTRIBUTE = 'spark/auth:token';
 


### PR DESCRIPTION
Nothing about this package is actually dependant on ADR. The only used
dependency was the `MiddlewareInterface`, which is not required to be
used with Relay.

By removing this dependency the middleware can be used in any PSR-7
compatible system.

Refs relayphp/Relay.Middleware#12